### PR TITLE
add apt update

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,14 @@
   tags:
     - always
 
+- name: Common | Run apt update
+  become: yes
+  apt:
+    update_cache: yes
+  when: ansible_facts['os_family'] == "Debian" and ansible_facts['distribution'] == "Ubuntu"
+  tags:
+    - packages
+
 - name: Common | Packages installation
   become: yes
   package:


### PR DESCRIPTION
The python3-pip package does not install without updating the apt repositories.